### PR TITLE
Set precision in float serialization for json encoding

### DIFF
--- a/easybitcoin.php
+++ b/easybitcoin.php
@@ -126,6 +126,12 @@ class Bitcoin
 
         // The ID should be unique for each call
         $this->id++;
+        
+        // Set precision of float serialization for json encoding
+        if (version_compare(phpversion(), '7.1', '>=')) {
+          ini_set( 'precision'          , 8 );
+          ini_set( 'serialize_precision', 8 );
+        }
 
         // Build the request, it's ok that params might have any empty array
         $request = json_encode(array(


### PR DESCRIPTION
I don't know how it worked with PHP versions below 7.1, but starting with 7.1 you need to set the serialization_precision to 8, because bitcoin core can only handle 1 / 100 000 000 of a bitcoin (=> 1 satoshi) at minimum.